### PR TITLE
added basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:alpine
+
+# Create app directory
+WORKDIR /app
+
+# Save that must be shared to the host
+RUN mkdir -p /app/saves
+VOLUME /app/saves
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN apk add --no-cache tzdata
+ENV TZ=Europe/Paris
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN npm install
+RUN npm run build
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+CMD [ "npm", "start" ]


### PR DESCRIPTION
So, I added a very simple Dockerfile that does the following:

- pulls the latest Node Alpine 
- creates folder "saves" in the image and mount the volume provided (see hereafter)
- copy package*.json files (both normal and lock)
- set the timezone to Europe/Paris (just in case)
- `npm install` and `npm run build`
- copy the repo at the root of the image's workdir
- starts with `npm start` when a container of this image is ran

Here's how to use it: 
```sh
cd /path/to/this/repo
docker build -t voice-chat-bot .
docker run -d -v /absolute/host/path/to/saves/:app/saves --restart=always --name=voice-chat-bot voice-chat-bot
```