### PR TITLE
Pr/permit multiple

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,24 @@ VOLUME /app/saves
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
 COPY package*.json ./
+COPY tsconfig.json ./
 
 RUN apk add --no-cache tzdata
 ENV TZ=Europe/Paris
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN npm install
-RUN npm run build
+RUN apk add --no-cache --virtual .gyp \
+        python \
+        make \
+        g++ \
+    && npm install \
+    && apk del .gyp
 # If you are building your code for production
 # RUN npm ci --only=production
 
 # Bundle app source
 COPY . .
+
+RUN npm run build
 
 CMD [ "npm", "start" ]

--- a/src/controllers/command.ts
+++ b/src/controllers/command.ts
@@ -7,6 +7,7 @@ import {
   GuildMember,
   DiscordAPIError,
   OverwriteResolvable,
+  Role,
 } from 'discord.js';
 import { getOwner, editOwnership } from '../models/Ownership';
 import { getGuildSetup } from '../models/GuildSetup';
@@ -257,7 +258,7 @@ async function unlockChannel(msg: Message, channel: VoiceChannel) {
 
 async function permitUser(msg: Message, channel: VoiceChannel, args: string) {
   try {
-    const allowed: any[] = [];
+    const allowed: (GuildMember | Role)[] = [];
     const allowedNames: string[] = [];
     msg.mentions.members?.each((m) => allowed.push(m));
     msg.mentions.roles.each((r) => allowed.push(r));

--- a/src/controllers/command.ts
+++ b/src/controllers/command.ts
@@ -257,48 +257,52 @@ async function unlockChannel(msg: Message, channel: VoiceChannel) {
 
 async function permitUser(msg: Message, channel: VoiceChannel, args: string) {
   try {
-    const allowed =
-      msg.mentions.members?.first() ??
-      msg.mentions.roles.first() ??
-      (await findUserInGuildByName(msg.guild!, args));
-    if (allowed) {
-      // So now we need to check if the owner sent a member or a role
-      if (allowed instanceof GuildMember) {
-        await channel.updateOverwrite(
-          allowed,
-          { CONNECT: true },
-          `Voice Bot: The owner (${msg.author.username}) wants to allow user (${
-            allowed.nickname ?? allowed.user.username
-          }) in their channel`
-        );
-        addHistoricPermission({
-          userId: msg.author.id,
-          permittedUserId: allowed.user.id,
-        });
-        msg.channel.send(
-          `✅ **${
-            allowed.nickname ?? allowed.user.username
-          }** can now join your channel!`
-        );
-      } else {
-        await channel.updateOverwrite(
-          allowed,
-          { CONNECT: true },
-          `Voice Bot: The owner (${msg.author.username}) wants to allow user (${allowed.name}) in their channel`
-        );
-        addHistoricPermission({
-          userId: msg.author.id,
-          permittedUserId: allowed.id,
-        });
-        msg.channel.send(
-          `✅ **@${allowed.name}** members can now join your channel!`
-        );
-      }
-    } else {
-      msg.channel.send(
-        'I could not find this user or role, please make sure you typed the name correctly and try again.'
-      );
+    const allowed: any[] = [];
+    const allowedNames: string[] = [];
+    msg.mentions.members?.each((m) => allowed.push(m));
+    msg.mentions.roles.each((r) => allowed.push(r));
+
+    if (allowed.length < 1) {
+      const nonMentionedUser = await findUserInGuildByName(msg.guild!, args);
+      if (nonMentionedUser) allowed.push(nonMentionedUser);
     }
+
+    allowed.forEach((a, i) => {
+      setTimeout(async () => {
+        if (a instanceof GuildMember) {
+          await channel.updateOverwrite(
+            a,
+            { CONNECT: true },
+            `Voice Bot: The owner (${
+              msg.author.username
+            }) wants to allow user (${
+              a.nickname ?? a.user.username
+            }) in their channel`
+          );
+          addHistoricPermission({
+            userId: msg.author.id,
+            permittedUserId: a.user.id,
+          });
+          allowedNames.push(a.nickname ?? a.user.username);
+        } else {
+          await channel.updateOverwrite(
+            a,
+            { CONNECT: true },
+            `Voice Bot: The owner (${msg.author.username}) wants to allow user (${a.name}) in their channel`
+          );
+          addHistoricPermission({
+            userId: msg.author.id,
+            permittedUserId: a.id,
+          });
+          allowedNames.push(a.name);
+        }
+        if (i === allowed.length - 1) {
+          msg.channel.send(
+            `✅ **${allowedNames.join(', ')}** can now join your channel!`
+          );
+        }
+      }, i * 25);
+    });
   } catch (error) {
     handleErrors(msg, error);
   }


### PR DESCRIPTION
Allow a channel's owner to `permit` multiple users and roles at once, like so : 

`!voice permit @role1 @user1 @role2 @user2 @role3 @user3` 

Only works with mentions, can't work with nicknames.